### PR TITLE
CLI Utility & New Compatibility Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,47 @@ pip install sharklocal
 
 ---
 
+## CLI Usage
+
+The library includes a built-in CLI utility for discovering, testing, and controlling your vacuum.
+
+### Discovery Probe
+
+Identify which mapping configuration works for your vacuum model. This is the recommended first step for new hardware:
+```bash
+python -m sharklocal <IP_ADDRESS> --probe
+```
+
+### Compatibility Testing
+
+Run non-destructive tests (Status, Events, Info) to verify support for local REST and MQTT features:
+```bash
+python -m sharklocal <IP_ADDRESS> --test
+```
+
+Run all tests, including destructive commands (Start, Stop, Dock), and automatically generate a compatibility matrix for contributing back to the project:
+```bash
+python -m sharklocal <IP_ADDRESS> --test-all --save-report
+```
+
+### Real-Time Monitoring
+
+Stream real-time status updates via MQTT. This is the best way to verify that a vacuum is correctly publishing its state:
+```bash
+python -m sharklocal <IP_ADDRESS> --monitor
+```
+
+### Direct Commands
+
+Send a specific command via a chosen transport (defaults to `mqtt`):
+```bash
+python -m sharklocal <IP_ADDRESS> --cmd dock --transport mqtt
+```
+
+Available commands: `start`, `stop`, `dock`, `status`, `events`, `info`.
+
+---
+
 ## Quickstart
 
 ```python

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -3,11 +3,13 @@
 This table lists known vacuum models and their support for the REST and MQTT transports.
 Visit a model's details page to see the full feature-level compatibility matrix for that model.
 
-| Model | REST | MQTT | Details |
-|-------|:----:|:----:|---------|
-| `example` | ✅ | ✅ | [Details](compatibility/template.md) |
+| Model        | REST | MQTT | Details                                |
+| ------------ | :--: | :--: | -------------------------------------- |
+| `RV2310CGUS` |  ❌  |  ✅  | [Details](compatibility/rv2310cgus.md) |
+| `RV1001AEC`  |  ❌  |  ❌  | [Details](compatibility/rv1001aec.md)  |
 
 > **Adding a new model?**
-> The goal is to identify both supported and known unsupported models.  This allows us to track and add new mappings targeted at specific models.  Please open a PR with the following changes to contribute to this list.
+> The goal is to identify both supported and known unsupported models. This allows us to track and add new mappings targeted at specific models. Please open a PR with the following changes to contribute to this list.
+>
 > 1. Create `docs/compatibility/{model}.md` using the template in [`compatibility/template.md`](compatibility/template.md) as a reference.
 > 2. Add a row to the table above with the model, transport support, and a link to the new file.

--- a/docs/compatibility/rv1001aec.md
+++ b/docs/compatibility/rv1001aec.md
@@ -1,0 +1,44 @@
+# RV1001AEC (Shark IQ) — Compatibility Matrix
+
+---
+
+## Actions
+
+| Feature | REST | MQTT | Supported mappings |
+|---------|:----:|:----:|--------------------|
+| Start cleaning | ❌ | ❌ | |
+| Stop | ❌ | ❌ | |
+| Return to dock | ❌ | ❌ | |
+| Explore / Map | ❌ | ❌ | |
+| Get status | ❌ | ❌ | |
+| Get event log | ❌ | ❌ | |
+| Get robot ID | ❌ | ❌ | |
+| Get Wi-Fi status | ❌ | ❌ | |
+
+---
+
+## Status Fields
+
+| Field | REST | MQTT | Supported mappings |
+|-------|:----:|:----:|--------------------|
+| Operating mode | ❌ | ❌ | |
+| Battery level | ❌ | ❌ | |
+| Charging status | ❌ | ❌ | |
+
+---
+
+## Operating Modes
+
+| Mode | REST | MQTT | Supported mappings |
+|------|:----:|:----:|--------------------|
+| `cleaning` | ❌ | ❌ | |
+| `returning_to_dock` | ❌ | ❌ | |
+| `docking` | ❌ | ❌ | |
+| `docked` | ❌ | ❌ | |
+| `idle` | ❌ | ❌ | |
+| `exploring` | ❌ | ❌ | |
+
+---
+
+## Known Issues / Notes
+- **Local Control Disabled:** Tested both Port 443 (HTTPS) and Port 80 (HTTP) for REST, and Port 1883 for MQTT. All connections were refused or failed to respond. This specific unit/firmware version appears to have all local communication ports locked down, restricting it to cloud-only control.

--- a/docs/compatibility/rv2310cgus.md
+++ b/docs/compatibility/rv2310cgus.md
@@ -1,0 +1,45 @@
+# RV2310CGUS (Shark Matrix) — Compatibility Matrix
+
+---
+
+## Actions
+
+| Feature | REST | MQTT | Supported mappings |
+|---------|:----:|:----:|--------------------|
+| Start cleaning | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Stop | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Return to dock | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Explore / Map | ❌ | ❌ | |
+| Get status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Get event log | ❌ | ❌ | |
+| Get robot ID | ❌ | ❌ | |
+| Get Wi-Fi status | ❌ | ❌ | |
+
+---
+
+## Status Fields
+
+| Field | REST | MQTT | Supported mappings |
+|-------|:----:|:----:|--------------------|
+| Operating mode | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Battery level | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Charging status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+
+---
+
+## Operating Modes
+
+| Mode | REST | MQTT | Supported mappings |
+|------|:----:|:----:|--------------------|
+| `cleaning` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `returning_to_dock` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docking` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docked` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `idle` | ❌ | ❌ | |
+| `exploring` | ❌ | ❌ | |
+
+---
+
+## Known Issues / Notes
+- **REST API:** Tested both Port 443 (HTTPS) and Port 80 (HTTP). Port 443 is closed/refused; Port 80 is open but does not respond to standard API endpoints. Local web API appears disabled on this firmware.
+- **MQTT:** Uses standard `sharkiq_v1` protobuf format. Successfully decodes Battery (Field 9.8) and Charging State (Field 9.1).

--- a/sharklocal/__main__.py
+++ b/sharklocal/__main__.py
@@ -1,0 +1,336 @@
+import asyncio
+import argparse
+import sys
+import os
+from datetime import datetime
+from typing import Optional, Any, Dict, List
+
+from . import (
+    RESTVacuumClient,
+    MQTTVacuumClient,
+    load_rest_mapping,
+    load_mqtt_mapping,
+    list_rest_mappings,
+    list_mqtt_mappings,
+    VacuumClient,
+    VacuumStatus,
+    VacuumMode,
+    SharklocalError
+)
+
+# Actions metadata for help and validation
+VALID_COMMANDS = ["start", "stop", "dock", "status", "events", "info"]
+ACTION_MAP = {
+    "status": "get_status",
+    "start": "start_cleaning",
+    "stop": "stop",
+    "dock": "go_home",
+    "events": "get_events",
+    "info": "get_robot_id",
+}
+
+def print_status(status: VacuumStatus, prefix: str = "[STATUS]"):
+    """Helper to format status output."""
+    bat = f"{status.battery_level}%" if status.battery_level is not None else "N/A"
+    chg = f" (Charging)" if status.charging else ""
+    print(f"\r{prefix} Mode: {status.mode:20} | Battery: {bat}{chg}", end="", flush=True)
+
+async def run_command(host: str, cmd: str, transport: str):
+    """Execute a single specific command."""
+    action = ACTION_MAP[cmd]
+    
+    if transport == "rest":
+        for m_id in list_rest_mappings():
+            try:
+                mapping = load_rest_mapping(m_id)
+                if action not in mapping.actions: continue
+                client = RESTVacuumClient(host, mapping)
+                print(f"Sending {cmd} via REST ({m_id})...")
+                res = await asyncio.wait_for(client.call(action), timeout=5.0)
+                print(f"Response: {res}")
+                await client.close()
+                return
+            except Exception as e:
+                print(f"REST {m_id} failed: {e}")
+    else:
+        for m_id in list_mqtt_mappings():
+            try:
+                mapping = load_mqtt_mapping(m_id)
+                if action not in mapping.actions: continue
+                client = MQTTVacuumClient(host, mapping)
+                print(f"Sending {cmd} via MQTT ({m_id})...")
+                res = await asyncio.wait_for(client.call(action), timeout=5.0)
+                print(f"Response: {res}")
+                return
+            except Exception as e:
+                print(f"MQTT {m_id} failed: {e}")
+
+async def monitor_vacuum(host: str):
+    """Start real-time monitoring via MQTT."""
+    print(f"Starting real-time monitoring for {host} (Ctrl+C to stop)...")
+    try:
+        mqtt_maps = list_mqtt_mappings()
+        if not mqtt_maps:
+            print("No MQTT mappings found.")
+            return
+            
+        async with VacuumClient(host, mqtt_mappings=mqtt_maps[0]) as vacuum:
+            vacuum.on_status_update(lambda s: print_status(s))
+            await vacuum.start_monitoring()
+            while True:
+                await asyncio.sleep(1)
+    except Exception as e:
+        print(f"\nMonitoring failed: {e}")
+
+async def run_probe(host: str):
+    """Perform a connectivity probe to identify working mappings."""
+    print(f"\n>>> PROBING: {host}")
+    
+    async with VacuumClient(
+        host,
+        rest_mappings=list_rest_mappings(),
+        mqtt_mappings=list_mqtt_mappings()
+    ) as vacuum:
+        print("Testing candidates...")
+        try:
+            res = await asyncio.wait_for(vacuum.probe(), timeout=15.0)
+            
+            print(f"\nResults:")
+            print(f"  REST Transport: {'PINNED [' + res.rest_mapping + ']' if res.has_rest else 'FAILED'}")
+            print(f"  MQTT Transport: {'PINNED [' + res.mqtt_mapping + ']' if res.has_mqtt else 'FAILED'}")
+            print(f"  Primary Conn:   {vacuum.via}")
+            
+            if not res.is_connected:
+                print("\nSuggestion: Verify that the vacuum is online and reachable at this IP.")
+            elif res.has_rest:
+                print("\nHint: Run with --test to see detailed device information.")
+        except asyncio.TimeoutError:
+            print("\nError: Probe timed out. The device may be offline or blocking local ports.")
+        except Exception as e:
+            print(f"\nError: {e}")
+
+async def test_vacuum_logic(host: str, test_commands: bool = False) -> Dict[str, Any]:
+    """Run compatibility suite and return structured results for reporting."""
+    print(f"\n>>> TESTING: {host}")
+    
+    results = {
+        "host": host,
+        "model": None,
+        "fw": None,
+        "rest": {},
+        "mqtt": {}
+    }
+
+    # 1. REST Probe
+    for m_id in list_rest_mappings():
+        try:
+            mapping = load_rest_mapping(m_id)
+            client = RESTVacuumClient(host, mapping)
+            print(f"  [REST] Mapping: {m_id}")
+            results["rest"][m_id] = {"actions": {}, "modes": set()}
+            
+            for raw_m, norm_m in mapping.mode_map.items():
+                results["rest"][m_id]["modes"].add(norm_m)
+                if norm_m == "docked" and raw_m == "ready":
+                    results["rest"][m_id]["modes"].add("idle")
+
+            actions_to_test = [
+                ("Status", "get_status"),
+                ("Explore", "explore"),
+                ("Events", "get_events"),
+                ("Info", "get_robot_id"),
+                ("Wi-Fi", "get_wifi_status")
+            ]
+            
+            for label, action in actions_to_test:
+                if action not in mapping.actions: continue
+                try:
+                    res = await asyncio.wait_for(client.call(action), timeout=5.0)
+                    results["rest"][m_id]["actions"][action] = True
+                    detail = ""
+                    if action == "get_status":
+                        detail = f" (Mode: {res.mode}, Bat: {res.battery_level}%, Chg: {res.charging})"
+                    elif action == "get_robot_id":
+                        detail = f" (FW: {res.firmware}, MAC: {res.mac_address})"
+                        results["fw"] = res.firmware
+                        results["model"] = res.raw.get("robot_model")
+                    elif action == "get_wifi_status":
+                        detail = f" (RSSI: {res.rssi})"
+                    elif action == "get_events":
+                        detail = f" ({len(res)} events found)"
+                    print(f"    - {label:10} ✅ SUCCESS{detail}")
+                except Exception as e:
+                    results["rest"][m_id]["actions"][action] = False
+                    print(f"    - {label:10} ❌ FAILED ({type(e).__name__})")
+            await client.close()
+        except Exception: pass
+
+    # 2. MQTT Probe
+    for m_id in list_mqtt_mappings():
+        try:
+            mapping = load_mqtt_mapping(m_id)
+            client = MQTTVacuumClient(host, mapping)
+            print(f"  [MQTT] Mapping: {m_id}")
+            results["mqtt"][m_id] = {"actions": {}, "fields": {}, "modes": set()}
+            
+            for norm_m in mapping.modes.values():
+                results["mqtt"][m_id]["modes"].add(norm_m)
+
+            try:
+                status = await asyncio.wait_for(client.call("get_status"), timeout=5.0)
+                results["mqtt"][m_id]["actions"]["get_status"] = True
+                results["mqtt"][m_id]["fields"]["battery"] = status.battery_level is not None
+                results["mqtt"][m_id]["fields"]["charging"] = status.charging is not None
+                
+                bat_support = "✅" if results["mqtt"][m_id]["fields"]["battery"] else "❌"
+                chg_support = "✅" if results["mqtt"][m_id]["fields"]["charging"] else "❌"
+                print(f"    - Status     ✅ SUCCESS (Mode: {status.mode}, Bat: {status.battery_level}%)")
+                print(f"    - Field Audit: Battery: {bat_support} | Charging: {chg_support}")
+            except Exception as e:
+                results["mqtt"][m_id]["actions"]["get_status"] = False
+                print(f"    - Status     ❌ FAILED ({type(e).__name__})")
+
+            for label, action in [("Start", "start_cleaning"), ("Stop", "stop"), ("Dock", "go_home")]:
+                if action not in mapping.actions: continue
+                if not test_commands:
+                    print(f"    - {label:10} ⏭️  SKIPPED")
+                    continue
+                try:
+                    await asyncio.wait_for(client.call(action), timeout=5.0)
+                    results["mqtt"][m_id]["actions"][action] = True
+                    print(f"    - {label:10} ✅ SUCCESS")
+                except Exception as e:
+                    results["mqtt"][m_id]["actions"][action] = False
+                    print(f"    - {label:10} ❌ FAILED ({type(e).__name__})")
+        except Exception: pass
+    
+    return results
+
+def generate_markdown_report(results: Dict[str, Any]) -> str:
+    """Format test results into a compatibility matrix markdown matching the template."""
+    model = results["model"] or "{model}"
+    
+    def check_act(transport: str, action: str):
+        for m in results[transport].values():
+            if m["actions"].get(action): return "✅"
+        return "❌"
+
+    def get_maps(act_or_mode: str, is_mode: bool = False):
+        mappings = []
+        for m_id, m in results["rest"].items():
+            if is_mode:
+                if act_or_mode in m["modes"]: mappings.append(f"REST: `{m_id}`")
+            else:
+                if m["actions"].get(act_or_mode): mappings.append(f"REST: `{m_id}`")
+        for m_id, m in results["mqtt"].items():
+            if is_mode:
+                if act_or_mode in m["modes"]: mappings.append(f"MQTT: `{m_id}`")
+            else:
+                if m["actions"].get(act_or_mode): mappings.append(f"MQTT: `{m_id}`")
+        
+        return "<br/> ".join(mappings) if mappings else "None"
+
+    report = f"# {model} — Compatibility Matrix\n\n---\n\n## Actions\n\n"
+    report += "| Feature | REST | MQTT | Supported mappings |\n"
+    report += "|---------|:----:|:----:|--------------------|\n"
+    
+    actions = [
+        ("Start cleaning", "start_cleaning"),
+        ("Stop", "stop"),
+        ("Return to dock", "go_home"),
+        ("Explore / Map", "explore"),
+        ("Get status", "get_status"),
+        ("Get event log", "get_events"),
+        ("Get robot ID", "get_robot_id"),
+        ("Get Wi-Fi status", "get_wifi_status"),
+    ]
+    for label, act in actions:
+        report += f"| {label} | {check_act('rest', act)} | {check_act('mqtt', act)} | {get_maps(act)} |\n"
+
+    report += "\n---\n\n## Status Fields\n\n"
+    report += "| Field | REST | MQTT | Supported mappings |\n"
+    report += "|-------|:----:|:----:|--------------------|\n"
+    
+    def check_field(transport: str, field_name: str):
+        if transport == "rest":
+            return check_act("rest", "get_status")
+        for m in results["mqtt"].values():
+            if m["fields"].get(field_name): return "✅"
+        return "❌"
+
+    report += f"| Operating mode | {check_act('rest', 'get_status')} | {check_act('mqtt', 'get_status')} | {get_maps('get_status')} |\n"
+    report += f"| Battery level | {check_act('rest', 'get_status')} | {check_field('mqtt', 'battery')} | {get_maps('get_status')} |\n"
+    report += f"| Charging status | {check_act('rest', 'get_status')} | {check_field('mqtt', 'charging')} | {get_maps('get_status')} |\n"
+
+    report += "\n---\n\n## Operating Modes\n\n"
+    report += "| Mode | REST | MQTT | Supported mappings |\n"
+    report += "|------|:----:|:----:|--------------------|\n"
+    
+    modes = [
+        ("`cleaning`          ", "cleaning"),
+        ("`returning_to_dock` ", "returning_to_dock"),
+        ("`docking`           ", "docking"),
+        ("`docked`            ", "docked"),
+        ("`idle`              ", "idle"),
+        ("`exploring`         ", "exploring"),
+    ]
+    
+    def check_mode(transport: str, mode: str):
+        for m in results[transport].values():
+            if m["actions"].get("get_status") and mode in m["modes"]:
+                return "✅"
+        return "❌"
+
+    for label, mode in modes:
+        report += f"| {label} | {check_mode('rest', mode)} | {check_mode('mqtt', mode)} | {get_maps(mode, is_mode=True)} |\n"
+
+    return report
+
+def main():
+    parser = argparse.ArgumentParser(prog="sharklocal", description="SharkLocal CLI Utility")
+    parser.add_argument("host", help="IP address of the vacuum")
+    parser.add_argument("--cmd", choices=VALID_COMMANDS, help="Execute a specific command")
+    parser.add_argument("--transport", choices=["rest", "mqtt"], default="mqtt", help="Transport for single command (default: mqtt)")
+    parser.add_argument("--monitor", action="store_true", help="Stream real-time status updates (MQTT)")
+    parser.add_argument("--probe", action="store_true", help="Discovery-only probe to identify working mappings")
+    parser.add_argument("--test", action="store_true", help="Run non-destructive compatibility tests")
+    parser.add_argument("--test-all", action="store_true", help="Run all compatibility tests, including destructive commands")
+    parser.add_argument("--save-report", nargs='?', const=True, help="Save result to a markdown compatibility report (optional: filepath)")
+    
+    args = parser.parse_args()
+
+    print("SharkLocal CLI Utility")
+    print("======================")
+    
+    try:
+        if args.monitor:
+            asyncio.run(monitor_vacuum(args.host))
+        elif args.probe:
+            asyncio.run(run_probe(args.host))
+        elif args.cmd:
+            asyncio.run(run_command(args.host, args.cmd, args.transport))
+        elif args.test or args.test_all or args.save_report:
+            results = asyncio.run(test_vacuum_logic(args.host, test_commands=args.test_all))
+            
+            if args.save_report:
+                report_md = generate_markdown_report(results)
+                
+                if isinstance(args.save_report, str):
+                    filename = args.save_report
+                else:
+                    model_name = results["model"] or f"unknown_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+                    filename = f"{model_name}.md"
+                
+                with open(filename, "w") as f:
+                    f.write(report_md)
+                print(f"\nReport saved to: {os.path.abspath(filename)}")
+        else:
+            parser.print_help()
+    except KeyboardInterrupt:
+        print("\nOperation cancelled by user.")
+    except Exception as e:
+        print(f"\nFATAL: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/sharklocal/__main__.py
+++ b/sharklocal/__main__.py
@@ -33,7 +33,8 @@ def print_status(status: VacuumStatus, prefix: str = "[STATUS]"):
     """Helper to format status output."""
     bat = f"{status.battery_level}%" if status.battery_level is not None else "N/A"
     chg = f" (Charging)" if status.charging else ""
-    print(f"\r{prefix} Mode: {status.mode:20} | Battery: {bat}{chg}", end="", flush=True)
+    mode_str = status.mode.value if hasattr(status.mode, "value") else str(status.mode)
+    print(f"\r{prefix} Mode: {mode_str:20} | Battery: {bat}{chg}", end="", flush=True)
 
 async def run_command(host: str, cmd: str, transport: str):
     """Execute a single specific command."""
@@ -109,7 +110,7 @@ async def run_probe(host: str):
         except Exception as e:
             print(f"\nError: {e}")
 
-async def test_vacuum_logic(host: str, test_commands: bool = False) -> Dict[str, Any]:
+async def run_test_logic(host: str, test_commands: bool = False) -> Dict[str, Any]:
     """Run compatibility suite and return structured results for reporting."""
     print(f"\n>>> TESTING: {host}")
     
@@ -284,9 +285,23 @@ def generate_markdown_report(results: Dict[str, Any]) -> str:
     for label, mode in modes:
         report += f"| {label} | {check_mode('rest', mode)} | {check_mode('mqtt', mode)} | {get_maps(mode, is_mode=True)} |\n"
 
+    # Known Issues notes
+    has_rest = any(any(v for v in m["actions"].values()) for m in results["rest"].values())
+    has_mqtt = any(any(v for v in m["actions"].values()) for m in results["mqtt"].values())
+    
+    if not has_rest or not has_mqtt:
+        report += "\n---\n\n## Known Issues / Notes\n"
+        if not has_rest and not has_mqtt:
+            report += "- **Local Control Disabled:** Both REST and MQTT ports appear locked down or unreachable.\n"
+        elif not has_rest:
+            report += "- **REST API:** Local REST API (Ports 443/80) is closed or non-responsive.\n"
+        elif not has_mqtt:
+            report += "- **MQTT:** Local MQTT broker (Port 1883) is closed or unreachable.\n"
+
     return report
 
-def main():
+def setup_argparse() -> argparse.ArgumentParser:
+    """Configure and return the argument parser."""
     parser = argparse.ArgumentParser(prog="sharklocal", description="SharkLocal CLI Utility")
     parser.add_argument("host", help="IP address of the vacuum")
     parser.add_argument("--cmd", choices=VALID_COMMANDS, help="Execute a specific command")
@@ -296,7 +311,24 @@ def main():
     parser.add_argument("--test", action="store_true", help="Run non-destructive compatibility tests")
     parser.add_argument("--test-all", action="store_true", help="Run all compatibility tests, including destructive commands")
     parser.add_argument("--save-report", nargs='?', const=True, help="Save result to a markdown compatibility report (optional: filepath)")
+    return parser
+
+def save_report(results: Dict[str, Any], save_report_arg: Any):
+    """Generate and save the markdown report."""
+    report_md = generate_markdown_report(results)
     
+    if isinstance(save_report_arg, str):
+        filename = save_report_arg
+    else:
+        model_name = results["model"] or f"unknown_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        filename = f"{model_name}.md"
+    
+    with open(filename, "w") as f:
+        f.write(report_md)
+    print(f"\nReport saved to: {os.path.abspath(filename)}")
+
+def main():
+    parser = setup_argparse()
     args = parser.parse_args()
 
     print("SharkLocal CLI Utility")
@@ -310,20 +342,9 @@ def main():
         elif args.cmd:
             asyncio.run(run_command(args.host, args.cmd, args.transport))
         elif args.test or args.test_all or args.save_report:
-            results = asyncio.run(test_vacuum_logic(args.host, test_commands=args.test_all))
-            
+            results = asyncio.run(run_test_logic(args.host, test_commands=args.test_all))
             if args.save_report:
-                report_md = generate_markdown_report(results)
-                
-                if isinstance(args.save_report, str):
-                    filename = args.save_report
-                else:
-                    model_name = results["model"] or f"unknown_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-                    filename = f"{model_name}.md"
-                
-                with open(filename, "w") as f:
-                    f.write(report_md)
-                print(f"\nReport saved to: {os.path.abspath(filename)}")
+                save_report(results, args.save_report)
         else:
             parser.print_help()
     except KeyboardInterrupt:
@@ -331,6 +352,8 @@ def main():
     except Exception as e:
         print(f"\nFATAL: {e}")
         sys.exit(1)
+        
+    print("\nDone.")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,486 @@
+"""Tests for sharklocal.__main__ CLI utility."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch, mock_open
+
+import pytest
+
+from sharklocal.__main__ import (
+    generate_markdown_report,
+    main,
+    print_status,
+    run_command,
+    run_probe,
+    run_test_logic,
+    save_report,
+    setup_argparse,
+    monitor_vacuum,
+)
+from sharklocal.models import DeviceInfo, ProbeResult, VacuumMode, VacuumStatus
+
+
+# ---------------------------------------------------------------------------
+# generate_markdown_report
+# ---------------------------------------------------------------------------
+
+def test_generate_markdown_report_success():
+    """Test report generation with successful results."""
+    results = {
+        "host": "1.2.3.4",
+        "model": "TEST_MODEL",
+        "fw": "v1.2.3",
+        "rest": {
+            "m1": {"actions": {"get_status": True, "get_robot_id": True}, "modes": {"cleaning", "docked"}}
+        },
+        "mqtt": {
+            "m1": {"actions": {"get_status": True, "start_cleaning": True}, "fields": {"battery": True, "charging": True}, "modes": {"cleaning", "docked", "docking"}}
+        }
+    }
+    report = generate_markdown_report(results)
+    assert "# TEST_MODEL — Compatibility Matrix" in report
+    assert "Start cleaning" in report and "MQTT: `m1`" in report
+    assert "Get status" in report and "REST: `m1`" in report and "MQTT: `m1`" in report
+    assert "Battery level" in report and "✅" in report
+    assert "docking" in report and "MQTT: `m1`" in report
+
+
+def test_generate_markdown_report_partial_rest():
+    """Test report generation with only REST working."""
+    results = {
+        "host": "1.2.3.4",
+        "model": "M1",
+        "fw": "v1",
+        "rest": {"m1": {"actions": {"get_status": True}, "modes": {"docked"}}},
+        "mqtt": {}
+    }
+    report = generate_markdown_report(results)
+    assert "- **MQTT:** Local MQTT broker (Port 1883) is closed or unreachable." in report
+
+
+def test_generate_markdown_report_partial_mqtt():
+    """Test report generation with only MQTT working."""
+    results = {
+        "host": "1.2.3.4",
+        "model": "M1",
+        "fw": "v1",
+        "rest": {},
+        "mqtt": {"m1": {"actions": {"get_status": True}, "fields": {"battery": True}, "modes": {"docked"}}}
+    }
+    report = generate_markdown_report(results)
+    assert "- **REST API:** Local REST API (Ports 443/80) is closed or non-responsive." in report
+
+
+def test_generate_markdown_report_none():
+    """Test report generation with no supported mappings."""
+    results = {
+        "host": "1.2.3.4",
+        "model": None,
+        "fw": None,
+        "rest": {},
+        "mqtt": {}
+    }
+    report = generate_markdown_report(results)
+    assert "# {model} — Compatibility Matrix" in report
+    assert "Start cleaning" in report and "None" in report
+    assert "**Local Control Disabled:**" in report
+
+
+# ---------------------------------------------------------------------------
+# run_command
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_command_rest():
+    """Test executing a command via REST."""
+    mock_mapping = MagicMock()
+    mock_mapping.actions = {"get_robot_id": MagicMock()}
+    mock_client = AsyncMock()
+    mock_client.call.return_value = DeviceInfo(firmware="v1")
+    
+    with patch("sharklocal.__main__.list_rest_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_rest_mapping", return_value=mock_mapping), \
+         patch("sharklocal.__main__.RESTVacuumClient", return_value=mock_client):
+        await run_command("1.2.3.4", "info", "rest")
+        
+    mock_client.call.assert_called_once_with("get_robot_id")
+    mock_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_command_rest_no_action():
+    """Test run_command when action is not in mapping."""
+    mock_mapping = MagicMock()
+    mock_mapping.actions = {}
+    
+    with patch("sharklocal.__main__.list_rest_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_rest_mapping", return_value=mock_mapping):
+        await run_command("1.2.3.4", "info", "rest")
+
+
+@pytest.mark.asyncio
+async def test_run_command_rest_failed():
+    """Test run_command when REST fails."""
+    mock_mapping = MagicMock()
+    mock_mapping.actions = {"get_robot_id": MagicMock()}
+    mock_client = AsyncMock()
+    mock_client.call.side_effect = Exception("error")
+    
+    with patch("sharklocal.__main__.list_rest_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_rest_mapping", return_value=mock_mapping), \
+         patch("sharklocal.__main__.RESTVacuumClient", return_value=mock_client), \
+         patch("builtins.print") as mock_print:
+        await run_command("1.2.3.4", "info", "rest")
+    
+    mock_print.assert_any_call("REST m1 failed: error")
+
+
+@pytest.mark.asyncio
+async def test_run_command_mqtt():
+    """Test executing a command via MQTT."""
+    mock_mapping = MagicMock()
+    mock_mapping.actions = {"go_home": MagicMock()}
+    mock_client = AsyncMock()
+    mock_client.call.return_value = True
+    
+    with patch("sharklocal.__main__.list_mqtt_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_mqtt_mapping", return_value=mock_mapping), \
+         patch("sharklocal.__main__.MQTTVacuumClient", return_value=mock_client):
+        await run_command("1.2.3.4", "dock", "mqtt")
+        
+    mock_client.call.assert_called_once_with("go_home")
+
+
+@pytest.mark.asyncio
+async def test_run_command_mqtt_no_action():
+    """Test run_command when action is not in MQTT mapping."""
+    mock_mapping = MagicMock()
+    mock_mapping.actions = {}
+    
+    with patch("sharklocal.__main__.list_mqtt_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_mqtt_mapping", return_value=mock_mapping):
+        await run_command("1.2.3.4", "dock", "mqtt")
+
+
+@pytest.mark.asyncio
+async def test_run_command_mqtt_failed():
+    """Test run_command when MQTT fails."""
+    mock_mapping = MagicMock()
+    mock_mapping.actions = {"go_home": MagicMock()}
+    mock_client = AsyncMock()
+    mock_client.call.side_effect = Exception("error")
+    
+    with patch("sharklocal.__main__.list_mqtt_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_mqtt_mapping", return_value=mock_mapping), \
+         patch("sharklocal.__main__.MQTTVacuumClient", return_value=mock_client), \
+         patch("builtins.print") as mock_print:
+        await run_command("1.2.3.4", "dock", "mqtt")
+    
+    mock_print.assert_any_call("MQTT m1 failed: error")
+
+
+# ---------------------------------------------------------------------------
+# run_probe
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_probe_success():
+    """Test the probe command."""
+    probe_res = ProbeResult(rest_mapping="r1", mqtt_mapping="m1")
+    mock_vacuum = AsyncMock()
+    mock_vacuum.probe.return_value = probe_res
+    mock_vacuum.via = "REST"
+    mock_vacuum.__aenter__.return_value = mock_vacuum
+
+    with patch("sharklocal.__main__.VacuumClient", return_value=mock_vacuum):
+        await run_probe("1.2.3.4")
+        
+    mock_vacuum.probe.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_probe_not_connected():
+    """Test the probe command when no transport works."""
+    probe_res = ProbeResult()
+    mock_vacuum = AsyncMock()
+    mock_vacuum.probe.return_value = probe_res
+    mock_vacuum.via = "NONE"
+    mock_vacuum.__aenter__.return_value = mock_vacuum
+
+    with patch("sharklocal.__main__.VacuumClient", return_value=mock_vacuum), \
+         patch("builtins.print") as mock_print:
+        await run_probe("1.2.3.4")
+        
+    mock_print.assert_any_call("\nSuggestion: Verify that the vacuum is online and reachable at this IP.")
+
+
+@pytest.mark.asyncio
+async def test_run_probe_failed():
+    """Test the probe command when it fails."""
+    mock_vacuum = AsyncMock()
+    mock_vacuum.probe.side_effect = Exception("error")
+    mock_vacuum.__aenter__.return_value = mock_vacuum
+
+    with patch("sharklocal.__main__.VacuumClient", return_value=mock_vacuum), \
+         patch("builtins.print") as mock_print:
+        await run_probe("1.2.3.4")
+    
+    mock_print.assert_any_call("\nError: error")
+
+
+@pytest.mark.asyncio
+async def test_run_probe_timeout():
+    """Test the probe command when it times out."""
+    mock_vacuum = AsyncMock()
+    mock_vacuum.probe.side_effect = asyncio.TimeoutError()
+    mock_vacuum.__aenter__.return_value = mock_vacuum
+
+    with patch("sharklocal.__main__.VacuumClient", return_value=mock_vacuum), \
+         patch("builtins.print") as mock_print:
+        await run_probe("1.2.3.4")
+    
+    mock_print.assert_any_call("\nError: Probe timed out. The device may be offline or blocking local ports.")
+
+
+# ---------------------------------------------------------------------------
+# run_test_logic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_test_logic_summary():
+    """Test the main test logic and result collection."""
+    mock_rest_mapping = MagicMock()
+    mock_rest_mapping.actions = ["get_status", "get_robot_id", "get_events", "get_wifi_status"]
+    mock_rest_mapping.mode_map = {"ready": "docked"}
+    
+    mock_rest_client = AsyncMock()
+    mock_rest_client.supports.side_effect = lambda a: True
+    mock_rest_client.call.side_effect = [
+        VacuumStatus(mode=VacuumMode.DOCKED, battery_level=100),
+        [], # Events
+        DeviceInfo(firmware="v1", mac_address="mac", raw={"robot_model": "M1"}), # Robot ID
+        DeviceInfo(rssi=-50) # Wi-Fi
+    ]
+
+    mock_mqtt_mapping = MagicMock()
+    mock_mqtt_mapping.actions = ["get_status", "start_cleaning"]
+    mock_mqtt_mapping.modes = {1: "cleaning"}
+
+    mock_mqtt_client = AsyncMock()
+    mock_mqtt_client.call.side_effect = [
+        VacuumStatus(mode=VacuumMode.CLEANING, battery_level=50),
+        True
+    ]
+
+    with patch("sharklocal.__main__.list_rest_mappings", return_value=["r1"]), \
+         patch("sharklocal.__main__.load_rest_mapping", return_value=mock_rest_mapping), \
+         patch("sharklocal.__main__.RESTVacuumClient", return_value=mock_rest_client), \
+         patch("sharklocal.__main__.list_mqtt_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_mqtt_mapping", return_value=mock_mqtt_mapping), \
+         patch("sharklocal.__main__.MQTTVacuumClient", return_value=mock_mqtt_client):
+        
+        results = await run_test_logic("1.2.3.4", test_commands=True)
+        
+    assert results["rest"]["r1"]["actions"]["get_status"] is True
+    assert results["mqtt"]["m1"]["actions"]["start_cleaning"] is True
+    assert results["model"] == "M1"
+    mock_rest_client.close.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_run_test_logic_failed():
+    """Test run_test_logic when actions fail."""
+    mock_rest_mapping = MagicMock()
+    mock_rest_mapping.actions = ["get_status"]
+    mock_rest_mapping.mode_map = {}
+    
+    mock_rest_client = AsyncMock()
+    mock_rest_client.call.side_effect = Exception("rest_error")
+
+    mock_mqtt_mapping = MagicMock()
+    mock_mqtt_mapping.actions = ["get_status"]
+    mock_mqtt_mapping.modes = {}
+
+    mock_mqtt_client = AsyncMock()
+    mock_mqtt_client.call.side_effect = Exception("mqtt_error")
+
+    with patch("sharklocal.__main__.list_rest_mappings", return_value=["r1"]), \
+         patch("sharklocal.__main__.load_rest_mapping", return_value=mock_rest_mapping), \
+         patch("sharklocal.__main__.RESTVacuumClient", return_value=mock_rest_client), \
+         patch("sharklocal.__main__.list_mqtt_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.load_mqtt_mapping", return_value=mock_mqtt_mapping), \
+         patch("sharklocal.__main__.MQTTVacuumClient", return_value=mock_mqtt_client):
+        
+        results = await run_test_logic("1.2.3.4", test_commands=False)
+        
+    assert results["rest"]["r1"]["actions"]["get_status"] is False
+    assert results["mqtt"]["m1"]["actions"]["get_status"] is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_print_status(capsys):
+    """Test the status printing helper."""
+    status = VacuumStatus(mode=VacuumMode.CLEANING, battery_level=80, charging=True)
+    print_status(status)
+    captured = capsys.readouterr()
+    assert "[STATUS] Mode: cleaning" in captured.out
+    assert "Battery: 80% (Charging)" in captured.out
+
+
+def test_setup_argparse():
+    """Test argument parser configuration."""
+    parser = setup_argparse()
+    args = parser.parse_args(["1.2.3.4", "--cmd", "start", "--transport", "mqtt"])
+    assert args.host == "1.2.3.4"
+    assert args.cmd == "start"
+    assert args.transport == "mqtt"
+
+
+def test_save_report_custom_filename():
+    """Test saving report to a custom file."""
+    results = {"model": "M1", "host": "1.2", "rest": {}, "mqtt": {}, "fw": None}
+    m = mock_open()
+    with patch("builtins.open", m):
+        save_report(results, "custom.md")
+    m.assert_called_once_with("custom.md", "w")
+    m().write.assert_called()
+
+
+def test_save_report_default_filename():
+    """Test saving report to default filename."""
+    results = {"model": "M1", "host": "1.2", "rest": {}, "mqtt": {}, "fw": None}
+    m = mock_open()
+    with patch("builtins.open", m):
+        save_report(results, True)
+    m.assert_called_once_with("M1.md", "w")
+
+
+def test_save_report_unknown_model():
+    """Test saving report when model is unknown."""
+    results = {"model": None, "host": "1.2", "rest": {}, "mqtt": {}, "fw": None}
+    m = mock_open()
+    with patch("builtins.open", m):
+        save_report(results, True)
+    # Check that it uses unknown_ prefix
+    args, _ = m.call_args
+    assert args[0].startswith("unknown_")
+
+
+@pytest.mark.asyncio
+async def test_monitor_vacuum_no_mqtt():
+    """Test monitor_vacuum when no mappings are found."""
+    with patch("sharklocal.__main__.list_mqtt_mappings", return_value=[]), \
+         patch("builtins.print") as mock_print:
+        await monitor_vacuum("1.2.3.4")
+    mock_print.assert_any_call("No MQTT mappings found.")
+
+
+@pytest.mark.asyncio
+async def test_monitor_vacuum_success():
+    """Test monitor_vacuum success (briefly)."""
+    mock_vacuum = AsyncMock()
+    mock_vacuum.__aenter__.return_value = mock_vacuum
+    mock_vacuum.on_status_update = MagicMock()
+    
+    async def side_effect(*args, **kwargs):
+        await asyncio.sleep(0.1)
+        raise KeyboardInterrupt()
+
+    with patch("sharklocal.__main__.list_mqtt_mappings", return_value=["m1"]), \
+         patch("sharklocal.__main__.VacuumClient", return_value=mock_vacuum), \
+         patch("asyncio.sleep", side_effect=side_effect):
+        try:
+            await monitor_vacuum("1.2.3.4")
+        except KeyboardInterrupt:
+            pass
+    
+    mock_vacuum.start_monitoring.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# main (CLI entry)
+# ---------------------------------------------------------------------------
+
+def test_main_help(capsys):
+    """Test that help is displayed when no args are provided."""
+    with patch("sys.argv", ["sharklocal"]):
+        with pytest.raises(SystemExit):
+            main()
+    captured = capsys.readouterr()
+    assert "usage: sharklocal" in captured.err
+
+
+def test_main_probe_dispatch():
+    """Test that --probe flag dispatches correctly."""
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--probe"]), \
+         patch("sharklocal.__main__.run_probe", new_callable=AsyncMock) as mock_run:
+        main()
+        mock_run.assert_called_once_with("1.2.3.4")
+
+
+def test_main_save_report():
+    """Test --save-report flag."""
+    results = {"host": "1.2", "model": "M1", "rest": {}, "mqtt": {}, "fw": None}
+    
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--save-report", "report.md"]), \
+         patch("sharklocal.__main__.run_test_logic", new_callable=AsyncMock, return_value=results), \
+         patch("sharklocal.__main__.save_report") as mock_save:
+        main()
+        
+    mock_save.assert_called_once_with(results, "report.md")
+
+
+def test_main_monitor_dispatch():
+    """Test --monitor flag dispatches correctly."""
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--monitor"]), \
+         patch("sharklocal.__main__.monitor_vacuum", new_callable=AsyncMock) as mock_run:
+        main()
+        mock_run.assert_called_once_with("1.2.3.4")
+
+
+def test_main_cmd_dispatch():
+    """Test --cmd flag dispatches correctly."""
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--cmd", "start"]), \
+         patch("sharklocal.__main__.run_command", new_callable=AsyncMock) as mock_run:
+        main()
+        mock_run.assert_called_once_with("1.2.3.4", "start", "mqtt")
+
+
+def test_main_test_dispatch():
+    """Test --test flag dispatches correctly."""
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--test"]), \
+         patch("sharklocal.__main__.run_test_logic", new_callable=AsyncMock) as mock_run:
+        main()
+        mock_run.assert_called_once_with("1.2.3.4", test_commands=False)
+
+
+def test_main_test_all_dispatch():
+    """Test --test-all flag dispatches correctly."""
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--test-all"]), \
+         patch("sharklocal.__main__.run_test_logic", new_callable=AsyncMock) as mock_run:
+        main()
+        mock_run.assert_called_once_with("1.2.3.4", test_commands=True)
+
+
+def test_main_keyboard_interrupt(capsys):
+    """Test main handling KeyboardInterrupt."""
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--monitor"]), \
+         patch("sharklocal.__main__.monitor_vacuum", side_effect=KeyboardInterrupt):
+        main()
+    captured = capsys.readouterr()
+    assert "Operation cancelled by user." in captured.out
+
+
+def test_main_fatal_error(capsys):
+    """Test main handling fatal errors."""
+    with patch("sys.argv", ["sharklocal", "1.2.3.4", "--probe"]), \
+         patch("sharklocal.__main__.run_probe", side_effect=Exception("fatal")):
+        with pytest.raises(SystemExit):
+            main()
+    captured = capsys.readouterr()
+    assert "FATAL: fatal" in captured.out


### PR DESCRIPTION
## Summary
This PR introduces a built-in CLI utility for the `sharklocal` library to simplify device discovery and testing. It also includes verified compatibility reports for the Shark Matrix (RV2310CGUS) and Shark IQ (RV1001AEC) models.

## Key Changes

### 1. Built-in CLI Utility (`python -m sharklocal`)
A comprehensive testing and diagnostic tool is now integrated directly into the package. Key features include:
- **Discovery Probing (`--probe`)**: Lightweight check to identify which mapping configuration matches a robot.
- **Functional Testing (`--test` / `--test-all`)**: Automated verification of REST and MQTT actions.
- **Real-time Monitoring (`--monitor`)**: Streams MQTT status updates for interactive state verification.
- **Automated Reporting (`--save-report`)**: Generates a formatted Markdown compatibility matrix matching the project template.

### 2. Verified Compatibility Reports
- **RV2310CGUS (Shark Matrix)**: Confirmed protocol parity with the Shark IQ line for MQTT. Status and commands are fully functional. REST ports (443/80) were found to be closed/non-responsive.
- **RV1001AEC (Shark IQ)**: Documented local lockdown on recent firmware; ports 443, 80, and 1883 are currently refusing local connections.

### 3. Documentation
- Updated `README.md` with a new **CLI Usage** section.
- Indexed new reports in `docs/COMPATIBILITY.md`.

## Generating Compatibility Reports
To make it easier for users to contribute data, the CLI can now automate the entire report generation process:

1. **Identify the mapping**: `python -m sharklocal <IP> --probe`
2. **Run verification & save**: `python -m sharklocal <IP> --test-all --save-report`

The tool will automatically detect the model number (if available) and write a valid `.md` file to the current directory, ready for submission.

### Sample CLI Help Output
```text
usage: sharklocal [-h] [--cmd {start,stop,dock,status,events,info}] [--transport {rest,mqtt}] [--monitor] [--probe] [--test] [--test-all] [--save-report [SAVE_REPORT]] host

SharkLocal CLI Utility

positional arguments:
  host                  IP address of the vacuum

options:
  -h, --help            show this help message and exit
  --cmd {start,stop,dock,status,events,info}
                        Execute a specific command
  --transport {rest,mqtt}
                        Transport for single command (default: mqtt)
  --monitor             Stream real-time status updates (MQTT)
  --probe               Discovery-only probe to identify working mappings
  --test                Run non-destructive compatibility tests
  --test-all            Run all compatibility tests, including destructive commands
  --save-report [SAVE_REPORT]
                        Save result to a markdown compatibility report (optional: filepath)
```

## Verification
Changes were verified against live hardware (RV2310CGUS and RV1001AEC). The CLI correctly identified working transports and successfully generated the attached compatibility reports.
