### PR TITLE
Add compatibility for Shark AI Ultra

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -7,6 +7,7 @@ Visit a model's details page to see the full feature-level compatibility matrix 
 | ------------ | :--: | :--: | -------------------------------------- |
 | `RV2310CGUS` |  ❌  |  ✅  | [Details](compatibility/rv2310cgus.md) |
 | `RV1001AEC`  |  ❌  |  ❌  | [Details](compatibility/rv1001aec.md)  |
+| `UR2500SR`   |  ❌  |  ✅  | [Details](compatibility/ur2500sr.md)   |
 
 > **Adding a new model?**
 > The goal is to identify both supported and known unsupported models. This allows us to track and add new mappings targeted at specific models. Please open a PR with the following changes to contribute to this list.

--- a/docs/compatibility/ur2500sr.md
+++ b/docs/compatibility/ur2500sr.md
@@ -1,0 +1,44 @@
+# UR2500SR/UR250BEXUS (Shark AI Ultra) — Compatibility Matrix
+
+---
+
+## Actions
+
+| Feature | REST | MQTT | Supported mappings |
+|---------|:----:|:----:|--------------------|
+| Start cleaning | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Stop | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Return to dock | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Explore / Map | ❌ | ❌ | None |
+| Get status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Get event log | ❌ | ❌ | None |
+| Get robot ID | ❌ | ❌ | None |
+| Get Wi-Fi status | ❌ | ❌ | None |
+
+---
+
+## Status Fields
+
+| Field | REST | MQTT | Supported mappings |
+|-------|:----:|:----:|--------------------|
+| Operating mode | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Battery level | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Charging status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+
+---
+
+## Operating Modes
+
+| Mode | REST | MQTT | Supported mappings |
+|------|:----:|:----:|--------------------|
+| `cleaning`           | ❌ | ✅ | REST: `sharkiq_v1`<br/> MQTT: `sharkiq_v1` |
+| `returning_to_dock`  | ❌ | ✅ | REST: `sharkiq_v1`<br/> MQTT: `sharkiq_v1` |
+| `docking`            | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docked`             | ❌ | ✅ | REST: `sharkiq_v1`<br/> MQTT: `sharkiq_v1` |
+| `idle`               | ❌ | ❌ | REST: `sharkiq_v1` |
+| `exploring`          | ❌ | ❌ | REST: `sharkiq_v1` |
+
+---
+
+## Known Issues / Notes
+- **REST API:** Local REST API (Ports 443/80) is closed or non-responsive.


### PR DESCRIPTION
Compatibility documentation generated as a report via the cli tool. This model uses model numbers UR2500SR and UR250BEXUS. I reflected this is the detailed doc, but not the higher level COMPATIBILITY.md.