### PR TITLE
docs: add RV2610BFCA compatibility report

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -7,6 +7,7 @@ Visit a model's details page to see the full feature-level compatibility matrix 
 | ------------ | :--: | :--: | -------------------------------------- |
 | `RV2310CGUS` |  ❌  |  ✅  | [Details](compatibility/rv2310cgus.md) |
 | `RV1001AEC`  |  ❌  |  ❌  | [Details](compatibility/rv1001aec.md)  |
+| `RV2610BFCA` |  ❌  |  ✅  | [Details](compatibility/rv2610bfca.md) |
 
 > **Adding a new model?**
 > The goal is to identify both supported and known unsupported models. This allows us to track and add new mappings targeted at specific models. Please open a PR with the following changes to contribute to this list.

--- a/docs/compatibility/rv2610bfca.md
+++ b/docs/compatibility/rv2610bfca.md
@@ -1,0 +1,49 @@
+# RV2610BFCA — Compatibility Matrix
+
+---
+
+## Actions
+
+| Feature | REST | MQTT | Supported mappings |
+|---------|:----:|:----:|--------------------|
+| Start cleaning | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Stop | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Return to dock | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Explore / Map | ❌ | ❌ | |
+| Get status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Get event log | ❌ | ❌ | |
+| Get robot ID | ❌ | ❌ | |
+| Get Wi-Fi status | ❌ | ❌ | |
+
+---
+
+## Status Fields
+
+| Field | REST | MQTT | Supported mappings |
+|-------|:----:|:----:|--------------------|
+| Operating mode | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Battery level | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Charging status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+
+---
+
+## Operating Modes
+
+| Mode | REST | MQTT | Supported mappings |
+|------|:----:|:----:|--------------------|
+| `cleaning` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `returning_to_dock` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docking` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docked` | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `idle` | ❌ | ❌ | |
+| `exploring` | ❌ | ❌ | |
+
+---
+
+## Known Issues / Notes
+
+- **REST API:** Port 443 is closed/refused. Port 80 is open, but `/get/status` and `/get/wifi_status` return `404 Not Found`, and `/` returns a forbidden HTML page.
+- **MQTT:** Uses standard `sharkiq_v1` protobuf format. Status requests, passive monitoring, and basic commands work.
+- **Observed MQTT status:** `mode=docked`, `battery_level=100`, `charging=true`.
+- **Command test:** `start_cleaning` returned `True` and status changed to `cleaning` within about 2 seconds. `stop` returned `True` and status changed to `returning_to_dock` within about 2 seconds. `go_home` returned `True`; the robot reported `docked` about 28 seconds after the first return-to-dock command.
+- **Command caveat:** In the current `sharkiq_v1` MQTT mapping, `stop` and `go_home` use the same payload, so both appear to initiate return-to-dock behavior on this model.


### PR DESCRIPTION
## Summary

- Add a compatibility report for the Shark RV2610BFCA.
- Add the model to the compatibility index.
- Document that REST is unavailable on this model, while MQTT works with the existing `sharkiq_v1` mapping.

## Live hardware results

Tested against an RV2610BFCA on current `main`.

- `--probe`: REST failed, MQTT pinned with `sharkiq_v1`.
- MQTT status: reported `docked`, battery level, and charging state correctly.
- MQTT monitoring: received passive status updates.
- MQTT commands: `start_cleaning`, `stop`, and `go_home` all returned `True`.
- Observed command behavior: `start_cleaning` changed status to `cleaning`; `stop` changed status to `returning_to_dock`; `go_home` returned success and the robot later reported `docked`.

## Notes

The current `sharkiq_v1` mapping uses the same MQTT payload for `stop` and `go_home`; on this model both appear to initiate return-to-dock behavior.

## Validation

- Live `python -m sharklocal <ip> --probe`
- Live `python -m sharklocal <ip> --test --save-report`
- Manual live MQTT command/status sequence

No automated tests were run for this docs-only change.