### PR TITLE
Feature/rest v2

### DIFF
--- a/docs/compatibility/rv2001drus.md
+++ b/docs/compatibility/rv2001drus.md
@@ -6,14 +6,14 @@
 
 | Feature | REST | MQTT | Supported mappings |
 |---------|:----:|:----:|--------------------|
-| Start cleaning | ✅ | ❌ | REST: `sharkiq_v1` |
-| Stop | ✅ | ❌ | REST: `sharkiq_v1` |
-| Return to dock | ✅ | ❌ | REST: `sharkiq_v1` |
-| Explore / Map | ✅ | ❌ | REST: `sharkiq_v1` |
-| Get status | ✅ | ❌ | REST: `sharkiq_v1` |
-| Get event log | ✅ | ❌ | REST: `sharkiq_v1` |
-| Get robot ID | ✅ | ❌ | REST: `sharkiq_v1` |
-| Get Wi-Fi status | ✅ | ❌ | REST: `sharkiq_v1` |
+| Start cleaning | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Stop | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Return to dock | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Explore / Map | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Get status | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Get event log | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Get robot ID | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Get Wi-Fi status | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
 
 ---
 
@@ -21,9 +21,9 @@
 
 | Field | REST | MQTT | Supported mappings |
 |-------|:----:|:----:|--------------------|
-| Operating mode | ✅ | ❌ | REST: `sharkiq_v1` |
-| Battery level | ✅ | ❌ | REST: `sharkiq_v1` |
-| Charging status | ✅ | ❌ | REST: `sharkiq_v1` |
+| Operating mode | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Battery level | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| Charging status | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
 
 ---
 
@@ -31,12 +31,12 @@
 
 | Mode | REST | MQTT | Supported mappings |
 |------|:----:|:----:|--------------------|
-| `cleaning`           | ✅ | ❌ | REST: `sharkiq_v1` |
-| `returning_to_dock`  | ✅ | ❌ | REST: `sharkiq_v1` |
+| `cleaning`           | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| `returning_to_dock`  | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
 | `docking`            | ❌ | ❌ | None |
-| `docked`             | ✅ | ❌ | REST: `sharkiq_v1` |
-| `idle`               | ✅ | ❌ | REST: `sharkiq_v1` |
-| `exploring`          | ✅ | ❌ | REST: `sharkiq_v1` |
+| `docked`             | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| `idle`               | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
+| `exploring`          | ✅ | ❌ | REST: `sharkiq_v1`, `sharkiq_v2` |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sharklocal"
-version = "0.1.0"
+version = "0.2.0"
 description = "Local control library for Shark robot vacuums, for use with Home Assistant"
 readme = "README.md"
 license = { text = "MIT" }

--- a/sharklocal/client.py
+++ b/sharklocal/client.py
@@ -176,23 +176,31 @@ class VacuumClient:
         rest_id: Optional[str] = None
         mqtt_id: Optional[str] = None
 
+        best_rest: Optional[RESTVacuumClient] = None
         for client in self._rest_candidates:
             try:
                 await client.call("get_status")
-                self._rest = client
-                rest_id = client.mapping.id
-                break
+                if best_rest is None or client.mapping.priority > best_rest.mapping.priority:
+                    best_rest = client
             except SharklocalError:
                 continue
 
+        if best_rest is not None:
+            self._rest = best_rest
+            rest_id = best_rest.mapping.id
+
+        best_mqtt: Optional[MQTTVacuumClient] = None
         for client in self._mqtt_candidates:
             try:
                 await client.call("get_status")
-                self._mqtt = client
-                mqtt_id = client.mapping.id
-                break
+                if best_mqtt is None or client.mapping.priority > best_mqtt.mapping.priority:
+                    best_mqtt = client
             except SharklocalError:
                 continue
+
+        if best_mqtt is not None:
+            self._mqtt = best_mqtt
+            mqtt_id = best_mqtt.mapping.id
 
         if rest_id is not None:
             self.via = "REST"

--- a/sharklocal/mappings/base.py
+++ b/sharklocal/mappings/base.py
@@ -37,6 +37,7 @@ class RESTMappingConfig:
     verify_ssl: bool
     actions: Dict[str, RESTActionSpec]
     mode_map: Dict[str, str] = field(default_factory=dict)
+    priority: int = 0
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> RESTMappingConfig:
@@ -59,6 +60,7 @@ class RESTMappingConfig:
             verify_ssl=conn.get("verify_ssl", True),
             actions=actions,
             mode_map=data.get("mode_map", {}),
+            priority=int(data.get("priority", 0)),
         )
 
 
@@ -75,6 +77,7 @@ class MQTTMappingConfig:
     status_decoder: str
     actions: Dict[str, MQTTActionSpec]
     modes: Dict[int, str]
+    priority: int = 0
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> MQTTMappingConfig:
@@ -99,4 +102,5 @@ class MQTTMappingConfig:
             status_decoder=data.get("status_decoder", ""),
             actions=actions,
             modes=modes,
+            priority=int(data.get("priority", 0)),
         )

--- a/sharklocal/mappings/mqtt/sharkiq_v1.yaml
+++ b/sharklocal/mappings/mqtt/sharkiq_v1.yaml
@@ -1,6 +1,7 @@
 id: sharkiq_v1
 description: "SharkIQ vacuum local MQTT protocol"
 transport: mqtt
+priority: 10
 connection:
   port: 1883
 

--- a/sharklocal/mappings/rest/sharkiq_v1.yaml
+++ b/sharklocal/mappings/rest/sharkiq_v1.yaml
@@ -1,6 +1,7 @@
 id: sharkiq_v1
 description: "SharkIQ vacuum local REST API (HTTPS with self-signed certificate)"
 transport: https
+priority: 15
 connection:
   port: 443
   verify_ssl: false

--- a/sharklocal/mappings/rest/sharkiq_v2.yaml
+++ b/sharklocal/mappings/rest/sharkiq_v2.yaml
@@ -1,0 +1,54 @@
+id: sharkiq_v2
+description: "SharkIQ vacuum local REST API (RobEye)"
+transport: http
+connection:
+  port: 8080
+  verify_ssl: false
+
+# Maps REST mode strings returned by /get/status to normalized VacuumMode values.
+# Note: "ready" mode requires combined evaluation with the "charging" field —
+# that logic lives in RESTVacuumClient._parse_status and cannot be expressed
+# here as a simple lookup. "ready" is mapped to "docked" as a safe default and
+# overridden to "idle" when charging is "unconnected".
+mode_map:
+  "ready": "docked"
+  "cleaning": "cleaning"
+  "go_home": "returning_to_dock"
+  "exploring": "exploring"
+
+actions:
+  start_cleaning:
+    method: GET
+    path: "/set/clean_all"
+
+  stop:
+    method: GET
+    path: "/set/stop"
+
+  go_home:
+    method: GET
+    path: "/set/go_home"
+
+  explore:
+    method: GET
+    path: "/set/explore"
+
+  get_status:
+    method: GET
+    path: "/get/status"
+    response_map: status
+
+  get_events:
+    method: GET
+    path: "/get/event_log"
+    response_map: events
+
+  get_robot_id:
+    method: GET
+    path: "/get/robot_id"
+    response_map: robot_id
+
+  get_wifi_status:
+    method: GET
+    path: "/get/wifi_status"
+    response_map: wifi_status

--- a/sharklocal/mappings/rest/sharkiq_v2.yaml
+++ b/sharklocal/mappings/rest/sharkiq_v2.yaml
@@ -1,6 +1,7 @@
 id: sharkiq_v2
-description: "SharkIQ vacuum local REST API (RobEye)"
+description: "SharkIQ vacuum local REST API (Direct control)"
 transport: http
+priority: 20
 connection:
   port: 8080
   verify_ssl: false

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,11 +23,12 @@ from sharklocal.models import DeviceInfo, ProbeResult, VacuumEvent, VacuumMode, 
 # ---------------------------------------------------------------------------
 
 
-def _make_rest_client_mock(action_result=None, raises=None, supports_actions=None):
+def _make_rest_client_mock(action_result=None, raises=None, supports_actions=None, priority=0):
     """Return a mock RESTVacuumClient."""
     mock = AsyncMock()
     mock.mapping = MagicMock()
     mock.mapping.id = "test_rest_v1"
+    mock.mapping.priority = priority
     _default_rest_actions = ["get_status", "start_cleaning", "stop", "go_home", "explore", "get_events", "get_robot_id", "get_wifi_status"]
     _actions = supports_actions if supports_actions is not None else _default_rest_actions
     mock.mapping.actions = {a: MagicMock() for a in _actions}
@@ -40,11 +41,12 @@ def _make_rest_client_mock(action_result=None, raises=None, supports_actions=Non
     return mock
 
 
-def _make_mqtt_client_mock(action_result=None, raises=None, supports_actions=None):
+def _make_mqtt_client_mock(action_result=None, raises=None, supports_actions=None, priority=0):
     """Return a mock MQTTVacuumClient."""
     mock = MagicMock()
     mock.mapping = MagicMock()
     mock.mapping.id = "test_mqtt_v1"
+    mock.mapping.priority = priority
     _default_mqtt_actions = ["get_status", "start_cleaning", "stop", "go_home"]
     _actions = supports_actions if supports_actions is not None else _default_mqtt_actions
     mock.mapping.actions = {a: MagicMock() for a in _actions}
@@ -289,6 +291,50 @@ async def test_probe_overwrites_previous_pin():
     rest_a.mapping.id = "test_rest_v1"
     result2 = await client.probe()
     assert result2.rest_mapping == "test_rest_v1"
+
+
+async def test_probe_selects_highest_priority_rest_mapping():
+    low = _make_rest_client_mock(action_result=VacuumStatus(mode=VacuumMode.DOCKED), priority=10)
+    low.mapping.id = "low_priority"
+    high = _make_rest_client_mock(action_result=VacuumStatus(mode=VacuumMode.DOCKED), priority=20)
+    high.mapping.id = "high_priority"
+
+    with patch("sharklocal.client.load_rest_mapping"), \
+         patch("sharklocal.client.RESTVacuumClient", side_effect=[low, high]):
+        client = VacuumClient("host", rest_mappings=["low", "high"])
+
+    result = await client.probe()
+    assert result.rest_mapping == "high_priority"
+    assert client._rest is high
+
+
+async def test_probe_selects_highest_priority_mqtt_mapping():
+    low = _make_mqtt_client_mock(action_result=VacuumStatus(mode=VacuumMode.DOCKED), priority=5)
+    low.mapping.id = "low_priority"
+    high = _make_mqtt_client_mock(action_result=VacuumStatus(mode=VacuumMode.DOCKED), priority=15)
+    high.mapping.id = "high_priority"
+
+    with patch("sharklocal.client.load_mqtt_mapping"), \
+         patch("sharklocal.client.MQTTVacuumClient", side_effect=[low, high]):
+        client = VacuumClient("host", mqtt_mappings=["low", "high"])
+
+    result = await client.probe()
+    assert result.mqtt_mapping == "high_priority"
+    assert client._mqtt is high
+
+
+async def test_probe_skips_failed_candidates_when_selecting_by_priority():
+    failing = _make_rest_client_mock(raises=ConnectError("unreachable"), priority=100)
+    failing.mapping.id = "high_but_fails"
+    working = _make_rest_client_mock(action_result=VacuumStatus(mode=VacuumMode.DOCKED), priority=10)
+    working.mapping.id = "low_but_works"
+
+    with patch("sharklocal.client.load_rest_mapping"), \
+         patch("sharklocal.client.RESTVacuumClient", side_effect=[failing, working]):
+        client = VacuumClient("host", rest_mappings=["high", "low"])
+
+    result = await client.probe()
+    assert result.rest_mapping == "low_but_works"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mappings_base.py
+++ b/tests/test_mappings_base.py
@@ -224,3 +224,46 @@ def test_mqtt_mapping_from_dict_defaults_when_keys_absent():
     assert cfg.encoding == "base64"
     assert cfg.modes == {}
     assert cfg.description == ""
+
+
+# ---------------------------------------------------------------------------
+# priority field
+# ---------------------------------------------------------------------------
+
+
+def test_rest_mapping_priority_default_is_zero():
+    minimal = {"id": "test", "actions": {}}
+    cfg = RESTMappingConfig.from_dict(minimal)
+    assert cfg.priority == 0
+
+
+def test_rest_mapping_priority_parsed_from_dict():
+    data = dict(_REST_DICT, priority=20)
+    cfg = RESTMappingConfig.from_dict(data)
+    assert cfg.priority == 20
+
+
+def test_rest_mapping_priority_coerced_to_int():
+    data = dict(_REST_DICT, priority="15")
+    cfg = RESTMappingConfig.from_dict(data)
+    assert cfg.priority == 15
+    assert isinstance(cfg.priority, int)
+
+
+def test_mqtt_mapping_priority_default_is_zero():
+    minimal = {"id": "test", "actions": {}, "status_decoder": ""}
+    cfg = MQTTMappingConfig.from_dict(minimal)
+    assert cfg.priority == 0
+
+
+def test_mqtt_mapping_priority_parsed_from_dict():
+    data = dict(_MQTT_DICT, priority=30)
+    cfg = MQTTMappingConfig.from_dict(data)
+    assert cfg.priority == 30
+
+
+def test_mqtt_mapping_priority_coerced_to_int():
+    data = dict(_MQTT_DICT, priority="5")
+    cfg = MQTTMappingConfig.from_dict(data)
+    assert cfg.priority == 5
+    assert isinstance(cfg.priority, int)


### PR DESCRIPTION
## REST v2 & Mapping Priority

### New Feature: Configurable mapping priority

Adds a `priority` field to REST and MQTT mapping configurations, allowing operators to declare which mapping should be preferred when multiple mappings are supported by a device.

#### What changed

**Mapping configs** (base.py)
- `RESTMappingConfig` and `MQTTMappingConfig` each gain a new `priority: int` field (default `0`)
- `from_dict()` reads `priority` from the YAML and coerces it to `int`

**Built-in YAML mappings**
| Mapping | Priority |
|---|---|
| `rest/sharkiq_v1` (HTTPS) | 15 |
| `rest/sharkiq_v2` (HTTP/Direct control) | 20 |
| `mqtt/sharkiq_v1` | 10 |

**`VacuumClient.probe()`** (client.py)
- Previously stopped at the **first** successful candidate per transport
- Now tests **all** candidates and pins the one with the **highest `priority`** value among those that respond successfully
- Failed candidates are still skipped; ties resolve to the first successful candidate encountered

#### Upgrading custom mappings

Add a top-level `priority` key to any custom YAML mapping file. Mappings without the key default to `0` and will lose out to any built-in mapping:

```yaml
id: my_custom_mapping
priority: 25          # beats sharkiq_v2 (20)
transport: http
connection:
  port: 8080
```

#### Tests

- test_mappings_base.py: 6 new tests covering default, explicit, and string-coerced priority values for both config types
- test_client.py: mock helpers updated with a `priority` parameter; 3 new probe tests covering highest-priority REST selection, highest-priority MQTT selection, and priority ignored for failing candidates