### PR TITLE
docs: add RV1100ARUS and UR2360EEUS compatibility report

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -20,3 +20,4 @@ Visit a model's details page to see the full feature-level compatibility matrix 
 | `UR2500SR`   |  ❌  |  ✅  | [Details](/docs/compatibility/ur2500sr.md)   |
 | `RV2001DRUS` |  ✅  |  ❌  | [Details](/docs/compatibility/rv2001drus.md)   |
 | `RV1100ARUS` |  ❌  |  ✅  | [Details](/docs/compatibility/RV1100ARUS_AV1110ARUS.md) |
+| `UR2360EEUS` |  ❌  |  ❌  | [Details](/docs/compatibility/UR2360EEUS.md) |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -19,3 +19,4 @@ Visit a model's details page to see the full feature-level compatibility matrix 
 | `RV2610BFCA` |  ❌  |  ✅  | [Details](/docs/compatibility/rv2610bfca.md) |
 | `UR2500SR`   |  ❌  |  ✅  | [Details](/docs/compatibility/ur2500sr.md)   |
 | `RV2001DRUS` |  ✅  |  ❌  | [Details](/docs/compatibility/rv2001drus.md)   |
+| `RV1100ARUS` |  ❌  |  ✅  | [Details](/docs/compatibility/RV1100ARUS_AV1110ARUS.md) |

--- a/docs/compatibility/RV1100ARUS_AV1110ARUS.md
+++ b/docs/compatibility/RV1100ARUS_AV1110ARUS.md
@@ -1,4 +1,4 @@
-# RV1100AR Series Shark IQ/AV1110ARUS — Compatibility Matrix
+# RV1100ARUS/AV1110ARUS — Compatibility Matrix
 
 ---
 

--- a/docs/compatibility/RV1100ARUS_AV1110ARUS.md
+++ b/docs/compatibility/RV1100ARUS_AV1110ARUS.md
@@ -31,12 +31,12 @@
 
 | Mode | REST | MQTT | Supported mappings |
 |------|:----:|:----:|--------------------|
-| `cleaning`           | ❌ | ✅ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
-| `returning_to_dock`  | ❌ | ✅ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
+| `cleaning`           | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `returning_to_dock`  | ❌ | ✅ | MQTT: `sharkiq_v1` |
 | `docking`            | ❌ | ✅ | MQTT: `sharkiq_v1` |
-| `docked`             | ❌ | ✅ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
-| `idle`               | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
-| `exploring`          | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
+| `docked`             | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `idle`               | ❌ | ❌ | None |
+| `exploring`          | ❌ | ❌ | None |
 
 ---
 

--- a/docs/compatibility/RV1100ARUS_AV1110ARUS.md
+++ b/docs/compatibility/RV1100ARUS_AV1110ARUS.md
@@ -1,0 +1,44 @@
+# RV1100AR Series Shark IQ/AV1110ARUS — Compatibility Matrix
+
+---
+
+## Actions
+
+| Feature | REST | MQTT | Supported mappings |
+|---------|:----:|:----:|--------------------|
+| Start cleaning | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Stop | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Return to dock | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Explore / Map | ❌ | ❌ | None |
+| Get status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Get event log | ❌ | ❌ | None |
+| Get robot ID | ❌ | ❌ | None |
+| Get Wi-Fi status | ❌ | ❌ | None |
+
+---
+
+## Status Fields
+
+| Field | REST | MQTT | Supported mappings |
+|-------|:----:|:----:|--------------------|
+| Operating mode | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Battery level | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Charging status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+
+---
+
+## Operating Modes
+
+| Mode | REST | MQTT | Supported mappings |
+|------|:----:|:----:|--------------------|
+| `cleaning`           | ❌ | ✅ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
+| `returning_to_dock`  | ❌ | ✅ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
+| `docking`            | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docked`             | ❌ | ✅ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
+| `idle`               | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
+| `exploring`          | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
+
+---
+
+## Known Issues / Notes
+- **REST API:** Local REST API (Ports 443/80) is closed or non-responsive.

--- a/docs/compatibility/UR2360EEUS.md
+++ b/docs/compatibility/UR2360EEUS.md
@@ -31,12 +31,12 @@
 
 | Mode | REST | MQTT | Supported mappings |
 |------|:----:|:----:|--------------------|
-| `cleaning`           | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
-| `returning_to_dock`  | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
-| `docking`            | ❌ | ❌ | MQTT: `sharkiq_v1` |
-| `docked`             | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
-| `idle`               | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
-| `exploring`          | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
+| `cleaning`           | ❌ | ❌ | None |
+| `returning_to_dock`  | ❌ | ❌ | None |
+| `docking`            | ❌ | ❌ | None |
+| `docked`             | ❌ | ❌ | None |
+| `idle`               | ❌ | ❌ | None |
+| `exploring`          | ❌ | ❌ | None |
 
 ---
 

--- a/docs/compatibility/UR2360EEUS.md
+++ b/docs/compatibility/UR2360EEUS.md
@@ -1,0 +1,44 @@
+# UR2360EEUS — Compatibility Matrix
+
+---
+
+## Actions
+
+| Feature | REST | MQTT | Supported mappings |
+|---------|:----:|:----:|--------------------|
+| Start cleaning | ❌ | ❌ | None |
+| Stop | ❌ | ❌ | None |
+| Return to dock | ❌ | ❌ | None |
+| Explore / Map | ❌ | ❌ | None |
+| Get status | ❌ | ❌ | None |
+| Get event log | ❌ | ❌ | None |
+| Get robot ID | ❌ | ❌ | None |
+| Get Wi-Fi status | ❌ | ❌ | None |
+
+---
+
+## Status Fields
+
+| Field | REST | MQTT | Supported mappings |
+|-------|:----:|:----:|--------------------|
+| Operating mode | ❌ | ❌ | None |
+| Battery level | ❌ | ❌ | None |
+| Charging status | ❌ | ❌ | None |
+
+---
+
+## Operating Modes
+
+| Mode | REST | MQTT | Supported mappings |
+|------|:----:|:----:|--------------------|
+| `cleaning`           | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
+| `returning_to_dock`  | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
+| `docking`            | ❌ | ❌ | MQTT: `sharkiq_v1` |
+| `docked`             | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2`<br/> MQTT: `sharkiq_v1` |
+| `idle`               | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
+| `exploring`          | ❌ | ❌ | REST: `sharkiq_v1`<br/> REST: `sharkiq_v2` |
+
+---
+
+## Known Issues / Notes
+- **Local Control Disabled:** Both REST and MQTT ports appear locked down or unreachable.


### PR DESCRIPTION
My older RV1100ARUS/AV1110ARUS connected via MQTT, but the newer "shark matrix" UR2360EEUS had no response. I confirmed that the UR2360EEUS is able to be pinged from my terminal. 

```
PING 192.168.0.242 (192.168.0.242): 56 data bytes
Request timeout for icmp_seq 0
64 bytes from 192.168.0.242: icmp_seq=0 ttl=64 time=1093.041 ms
64 bytes from 192.168.0.242: icmp_seq=1 ttl=64 time=87.976 ms
64 bytes from 192.168.0.242: icmp_seq=2 ttl=64 time=38.081 ms
64 bytes from 192.168.0.242: icmp_seq=3 ttl=64 time=55.635 ms
64 bytes from 192.168.0.242: icmp_seq=4 ttl=64 time=3.581 ms
```