### PR TITLE
Add compatibility for AV251WAXUS, and fix markdown generating bug

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -21,3 +21,4 @@ Visit a model's details page to see the full feature-level compatibility matrix 
 | `RV2001DRUS` |  ✅  |  ❌  | [Details](/docs/compatibility/rv2001drus.md)   |
 | `RV1100ARUS` |  ❌  |  ✅  | [Details](/docs/compatibility/RV1100ARUS_AV1110ARUS.md) |
 | `UR2360EEUS` |  ❌  |  ❌  | [Details](/docs/compatibility/UR2360EEUS.md) |
+| `AV251WAXUS` |  ❌  |  ✅  | [Details](/docs/compatibility/av251waxus.md) |

--- a/docs/compatibility/av251waxus.md
+++ b/docs/compatibility/av251waxus.md
@@ -1,0 +1,44 @@
+# AV251WAXUS (Shark AI Ultra) — Compatibility Matrix
+
+---
+
+## Actions
+
+| Feature | REST | MQTT | Supported mappings |
+|---------|:----:|:----:|--------------------|
+| Start cleaning | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Stop | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Return to dock | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Explore / Map | ❌ | ❌ | None |
+| Get status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Get event log | ❌ | ❌ | None |
+| Get robot ID | ❌ | ❌ | None |
+| Get Wi-Fi status | ❌ | ❌ | None |
+
+---
+
+## Status Fields
+
+| Field | REST | MQTT | Supported mappings |
+|-------|:----:|:----:|--------------------|
+| Operating mode | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Battery level | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| Charging status | ❌ | ✅ | MQTT: `sharkiq_v1` |
+
+---
+
+## Operating Modes
+
+| Mode | REST | MQTT | Supported mappings |
+|------|:----:|:----:|--------------------|
+| `cleaning`           | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `returning_to_dock`  | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docking`            | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `docked`             | ❌ | ✅ | MQTT: `sharkiq_v1` |
+| `idle`               | ❌ | ❌ | None |
+| `exploring`          | ❌ | ❌ | None |
+
+---
+
+## Known Issues / Notes
+- **REST API:** Local REST API (Ports 443/80) is closed or non-responsive.

--- a/sharklocal/__main__.py
+++ b/sharklocal/__main__.py
@@ -220,14 +220,18 @@ def generate_markdown_report(results: Dict[str, Any]) -> str:
         mappings = []
         for m_id, m in results["rest"].items():
             if is_mode:
-                if act_or_mode in m["modes"]: mappings.append(f"REST: `{m_id}`")
+                if m["actions"].get("get_status") and act_or_mode in m["modes"]:
+                    mappings.append(f"REST: `{m_id}`")
             else:
-                if m["actions"].get(act_or_mode): mappings.append(f"REST: `{m_id}`")
+                if m["actions"].get(act_or_mode):
+                    mappings.append(f"REST: `{m_id}`")
         for m_id, m in results["mqtt"].items():
             if is_mode:
-                if act_or_mode in m["modes"]: mappings.append(f"MQTT: `{m_id}`")
+                if m["actions"].get("get_status") and act_or_mode in m["modes"]:
+                    mappings.append(f"MQTT: `{m_id}`")
             else:
-                if m["actions"].get(act_or_mode): mappings.append(f"MQTT: `{m_id}`")
+                if m["actions"].get(act_or_mode):
+                    mappings.append(f"MQTT: `{m_id}`")
         
         return "<br/> ".join(mappings) if mappings else "None"
 


### PR DESCRIPTION
1. Add compatibility for AV251WAXUS. However, based on their support site, this is equivalent to UR2500SR which is already present. I'm not sure how best to indicate this, as it would be difficult to click into each compatibility MD to see whether it is cross-listed - maybe adding another column to the main table? Probably a future concern, as there's many many cross-listings
https://support.sharkninja.com/en-CA/product/rv2500av2500ur2500-icon-led-interface-series/01tHs00000D0UbhIAF

2. When running test-all, the output included both REST APIs in Supported mappings under Operating Modes regardless of whether the HTTP request returns or not. This should be fixed now, matching a similar condition below

Let me know if there's anything to change!