### PR TITLE
Prioritize charging state in MQTT status decoder

### DIFF
--- a/sharklocal/mqtt_client.py
+++ b/sharklocal/mqtt_client.py
@@ -51,13 +51,6 @@ def _decode_sharkiq_protobuf_v1(
     """
     raw = protobuf.decode_raw(payload)
 
-    mode_int = raw.get(4, 0)
-    mode_str = modes.get(mode_int, "unknown")
-    try:
-        mode = VacuumMode(mode_str)
-    except ValueError:
-        mode = VacuumMode.UNKNOWN
-
     battery_info = raw.get(9, {})
     battery_percent: Optional[int] = None
     charging: Optional[bool] = None
@@ -65,6 +58,18 @@ def _decode_sharkiq_protobuf_v1(
         battery_percent = battery_info.get(8)
         charging_state = battery_info.get(1, 0)
         charging = charging_state == 3  # ChargingState.CHARGING_ON_DOCK
+
+    # The vacuum can report a transient returning mode while already charging.
+    # Charging on the dock is the authoritative normalized state.
+    if charging:
+        mode = VacuumMode.DOCKED
+    else:
+        mode_int = raw.get(4, 0)
+        mode_str = modes.get(mode_int, "unknown")
+        try:
+            mode = VacuumMode(mode_str)
+        except ValueError:
+            mode = VacuumMode.UNKNOWN
 
     return VacuumStatus(
         mode=mode,

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -131,6 +131,13 @@ def test_decode_sharkiq_charging_state_3_means_charging():
     assert result.charging is True
 
 
+def test_decode_sharkiq_charging_overrides_returning_mode():
+    payload = _build_status_payload(7, 3, 80)
+    result = _decode_sharkiq_protobuf_v1(payload, _MODES)
+    assert result.mode == VacuumMode.DOCKED
+    assert result.charging is True
+
+
 def test_decode_sharkiq_charging_state_0_not_charging():
     payload = _build_status_payload(6, 0, 80)
     result = _decode_sharkiq_protobuf_v1(payload, _MODES)
@@ -341,7 +348,7 @@ async def test_request_status_returns_decoded_status(mqtt_mapping):
             result = await client.call("get_status")
 
     assert isinstance(result, VacuumStatus)
-    assert result.mode == VacuumMode.CLEANING
+    assert result.mode == VacuumMode.DOCKED
     assert result.battery_level == 80
     assert result.charging is True
 
@@ -410,7 +417,7 @@ async def test_monitor_invokes_sync_callback(mqtt_mapping):
         await client.monitor(callback)
 
     assert len(received) == 1
-    assert received[0].mode == VacuumMode.CLEANING
+    assert received[0].mode == VacuumMode.DOCKED
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #31

## Summary
- Treat CHARGING_ON_DOCK as the authoritative normalized state
- Report DOCKED instead of transient RETURNING_TO_DOCK while charging
- Add regression coverage

Tests: .venv/bin/python -m pytest tests/test_mqtt_client.py